### PR TITLE
Static pointer memory leak fix

### DIFF
--- a/src/real_sense_grabber.cpp
+++ b/src/real_sense_grabber.cpp
@@ -138,6 +138,8 @@ pcl::RealSenseGrabber::~RealSenseGrabber () throw ()
 
   disconnect_all_slots<sig_cb_real_sense_point_cloud> ();
   disconnect_all_slots<sig_cb_real_sense_point_cloud_rgba> ();
+  
+  RealSenseDeviceManager::getInstance().reset();
 }
 
 void


### PR DESCRIPTION
getInstance () at rs/include/real_sense/real_sense_device_manager.h line 76, is defining static pointer variable 'instance' that is not getting reset/destroyed on stop, and caused issue when you need to call start/stop multiple times within same application.
